### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.pytest_cache/
+.venv/
+venv/


### PR DESCRIPTION
To prevent pyc files, venvs and pytest's cache from being accidentally committed to the repo.