### PR TITLE
Update to use External Client App instead of Connected App

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This final step publishes your API to Salesforce and creates the necessary compo
 heroku salesforce:publish api-spec.yaml \
   --client-name MyAPI \
   --connection-name CONNECTION_NAME \
-  --authorization-connected-app-name MyAppLinkConnectedApp \
+  --authorization-external-client-app-name MyAppLinkExternalClientApp \
   --authorization-permission-set-name MyAppLinkPermSet \
   --addon YOUR_ADDON_NAME
 ```
@@ -202,7 +202,7 @@ heroku salesforce:publish api-spec.yaml \
 **Parameter Breakdown:**
 - `--client-name`: The name for the External Service and its generated Apex classes (e.g., `MyAPI`).
 - `--connection-name`: The friendly name you gave the AppLink connection in the previous step (e.g., `production_org`).
-- `--authorization-connected-app-name`: The name for the **new** Connected App that Heroku will create. **Note:** This value must match the `connectedApp` value defined in `api-spec.yaml`.
+- `--authorization-external-client-app-name`: The name for the **new** External Client App that Heroku will create. **Note:** This value must match the `externalClientApp` value defined in `api-spec.yaml`.
 - `--authorization-permission-set-name`: The name for the **new** Permission Set that Heroku will create. **Note:** This value must match the `permissionSet` value defined in `api-spec.yaml`.
 - `--addon`: The unique name of your AppLink add-on (e.g., `applink-slippery-54321`).
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -16,7 +16,7 @@ paths:
       x-sfdc:
         heroku:
           authorization:
-            connectedApp: 'MyAppLinkConnectedApp'
+            externalClientApp: 'MyAppLinkExternalClientApp'
             permissionSet: 'MyAppLinkPermSet'
       responses:
         '200':
@@ -41,7 +41,7 @@ paths:
       x-sfdc:
         heroku:
           authorization:
-            connectedApp: 'MyAppLinkConnectedApp'
+            externalClientApp: 'MyAppLinkExternalClientApp'
             permissionSet: 'MyAppLinkPermSet'
       requestBody:
         required: true


### PR DESCRIPTION
Updates the API specification to use Salesforce External Client Apps instead of Connected Apps, following [Salesforce's Spring '26 changes](https://help.salesforce.com/s/articleView?id=005228017&type=1).

## Changes

- Updated `api-spec.yaml` to use `externalClientApp: 'MyAppLinkExternalClientApp'` instead of `connectedApp: 'MyAppLinkConnectedApp'` (2 endpoints)

## Context

As of Salesforce Spring '26, new connected apps can no longer be created. This change updates the example to use external client apps, which is now the recommended approach for new integrations.

## Backward Compatibility

Existing implementations using connected apps will continue to work. This change only affects new installations following this tutorial.